### PR TITLE
Refactor sample application

### DIFF
--- a/webfluxquestion/pom.xml
+++ b/webfluxquestion/pom.xml
@@ -1,26 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.3.3.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.2.RELEASE</version>
-        <relativePath/>
-    </parent>
+	<groupId>webflux.question</groupId>
+	<artifactId>webfluxquestion</artifactId>
+	<version>1.0-SNAPSHOT</version>
 
-    <groupId>webflux.question</groupId>
-    <artifactId>webfluxquestion</artifactId>
-    <version>1.0-SNAPSHOT</version>
-
-    <dependencies>
-    <dependency>
-        <groupId>org.springframework.boot</groupId>
-<!--        <artifactId>spring-boot-starter-web</artifactId>-->
-        <artifactId>spring-boot-starter-webflux</artifactId>
-    </dependency>
-    </dependencies>
+	<properties>
+		<java.version>11</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/webfluxquestion/src/main/java/com/webflux/QuestionApplication.java
+++ b/webfluxquestion/src/main/java/com/webflux/QuestionApplication.java
@@ -1,72 +1,13 @@
 package com.webflux;
 
-import com.webflux.model.*;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
-@Controller
 @SpringBootApplication
 public class QuestionApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(QuestionApplication.class);
-    }
-
-    @PostMapping(path = "/question", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<QuestionResponse>> refundCustomer(@RequestBody QuestionRequest questionRequest) {
-        Mono<FirstStep> firstStepMono = getFirstStepObjectFromQuestionRequest(questionRequest);
-
-        Mono<SecondStep> secondStepMono = firstStepMono.flatMap(this::getSecondStepObjectFromFirstStepObject);
-
-        Mono<ThirdStep> thirdStepMono = secondStepMono.flatMap(this::getThirdStepObjectFromSecondStepObject);
-
-        Mono<QuestionResponse> questionResponseMono = Mono.zip(firstStepMono, secondStepMono, thirdStepMono).flatMap(tuple -> getQuestionResponseFromAllThreeSteps(tuple.getT1(), tuple.getT2(), tuple.getT3()));
-
-        return questionResponseMono.map(ResponseEntity::ok);
-    }
-
-    private Mono<FirstStep> getFirstStepObjectFromQuestionRequest(QuestionRequest questionRequest) {
-        String secretKey = getSecretKeyFromQuestionRequest(questionRequest);
-        return WebClient.create().post().uri("http://firstWebService:8111/getFirstStep")
-                .body(Mono.just(secretKey), String.class).retrieve().bodyToMono(FirstStep.class);
-    }
-
-    private Mono<SecondStep> getSecondStepObjectFromFirstStepObject(FirstStep firstStepObject) {
-        String something = getSomethingFromFirstStepObject(firstStepObject);
-        return WebClient.create().post().uri("http://secondWebService:8222/getSecondStep")
-                .body(Mono.just(something), String.class).retrieve().bodyToMono(SecondStep.class);
-    }
-
-    private Mono<ThirdStep> getThirdStepObjectFromSecondStepObject(SecondStep secondStepObject) {
-        String somethingElse = getSomethingElseFromSecondStepObject(secondStepObject);
-        return WebClient.create().post().uri("http://thirdWebService:8333/getThirdStep")
-                .body(Mono.just(somethingElse), String.class).retrieve().bodyToMono(ThirdStep.class);
-    }
-
-    private Mono<QuestionResponse> getQuestionResponseFromAllThreeSteps(FirstStep firstStep, SecondStep secondStep, ThirdStep thirdStep) {
-        return Mono.just(new QuestionResponse(firstStep.getThingNeededInTheFinalResponse(), secondStep.getThingNeededInTheFinalResponse(), thirdStep.getThingNeededInTheFinalResponse()));
-    }
-
-    private String getSecretKeyFromQuestionRequest(QuestionRequest questionRequest) {
-        System.out.println("I am a super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
-        return questionRequest.getThing().concat("dummy");
-    }
-
-    private String getSomethingFromFirstStepObject(FirstStep firstStepObject) {
-        System.out.println("I am another super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
-        return firstStepObject.getThingNeededInOrderToGetTheSecondStepObject().concat("anotherDummy");
-    }
-
-    private String getSomethingElseFromSecondStepObject(SecondStep secondStepObject) {
-        System.out.println("I am another other super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
-        return secondStepObject.getThingNeededInOrderToGetTheThirdStepObject().concat("anotherOtherDummy");
     }
 
 }

--- a/webfluxquestion/src/main/java/com/webflux/QuestionController.java
+++ b/webfluxquestion/src/main/java/com/webflux/QuestionController.java
@@ -1,0 +1,77 @@
+package com.webflux;
+
+import com.webflux.model.FirstStep;
+import com.webflux.model.QuestionRequest;
+import com.webflux.model.QuestionResponse;
+import com.webflux.model.SecondStep;
+import com.webflux.model.ThirdStep;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+public class QuestionController {
+
+	@PostMapping(path = "/question", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public Mono<ResponseEntity<QuestionResponse>> refundCustomer(@RequestBody QuestionRequest questionRequest) {
+		return getFirstStepObjectFromQuestionRequest(questionRequest)
+				.flatMap(this::getSecondStepObjectFromFirstStepObject)
+				.flatMap((secondStep) -> getThirdStepObjectFromSecondStepObject(secondStep))
+				.map(ResponseEntity::ok);
+	}
+
+	private Mono<Tuple2<FirstStep, QuestionResponse>> getFirstStepObjectFromQuestionRequest(QuestionRequest questionRequest) {
+		String secretKey = getSecretKeyFromQuestionRequest(questionRequest);
+		// webclient call to external service
+		Mono<FirstStep> firstStep = Mono.just(new FirstStep("firstOne", "firstTwo"));
+		return firstStep.map((step) -> {
+			QuestionResponse response = new QuestionResponse();
+			response.setThingFromTheFirstStep(step.getThingNeededInTheFinalResponse());
+			return Tuples.of(step, response);
+		});
+	}
+
+	private Mono<Tuple2<SecondStep, QuestionResponse>> getSecondStepObjectFromFirstStepObject(Tuple2<FirstStep, QuestionResponse> tuple) {
+		String something = getSomethingFromFirstStepObject(tuple.getT1());
+		// webclient call to external service
+		Mono<SecondStep> secondStep = Mono.just(new SecondStep("secondOne", "secondTwo"));
+		return secondStep.map((step) -> {
+			QuestionResponse response = tuple.getT2();
+			response.setThingFromTheSecondStep(step.getThingNeededInTheFinalResponse());
+			return Tuples.of(step, response);
+		});
+	}
+
+	private Mono<QuestionResponse> getThirdStepObjectFromSecondStepObject(Tuple2<SecondStep, QuestionResponse> tuple) {
+		String somethingElse = getSomethingElseFromSecondStepObject(tuple.getT1());
+		// webclient call to external service
+		Mono<ThirdStep> thirdStep = Mono.just(new ThirdStep("thirdOne"));
+		return thirdStep.map((step) -> {
+			QuestionResponse response = tuple.getT2();
+			response.setThingFromTheThirdStep(step.getThingNeededInTheFinalResponse());
+			return response;
+		});
+	}
+
+	private String getSecretKeyFromQuestionRequest(QuestionRequest questionRequest) {
+		System.out.println("I am a super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
+		return questionRequest.getThing().concat("dummy");
+	}
+
+	private String getSomethingFromFirstStepObject(FirstStep firstStepObject) {
+		System.out.println("I am another super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
+		return firstStepObject.getThingNeededInOrderToGetTheSecondStepObject().concat("anotherDummy");
+	}
+
+	private String getSomethingElseFromSecondStepObject(SecondStep secondStepObject) {
+		System.out.println("I am another other super heavy operation. I should be done only once. You should also see this line printed only once, But no...");
+		return secondStepObject.getThingNeededInOrderToGetTheThirdStepObject().concat("anotherOtherDummy");
+	}
+
+}

--- a/webfluxquestion/src/main/resources/application.properties
+++ b/webfluxquestion/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-server.port=9999
+#server.port=9999

--- a/webfluxquestion/webfluxquestion.iml
+++ b/webfluxquestion/webfluxquestion.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />


### PR DESCRIPTION
Prior to this PR, the REST calls to external services would be performed twice:

* once when calling `flatMap` from each step to get the next
* and then another when calling `Mono.zip` on all those steps

As a general point, applications should avoid as much as possible chaining calls to external services as latency and issues tend to accumulate. If you can't get around this by caching or parallelizing calls, you could still consider other ways. This sample is very generic so I can't really advise something specific. But let's say one of those steps is about getting information from the HTTP header and checking credentials: you could externalize that cross-cutting concern into a `WebFilter`.

This PR is trying to simplify things and come up with a single reactive pipeline in the controller (i.e. a single input, and chaining calls with operators, returning the result). For that, we need to use Reactor's `Tuples` (or anything similar like apache commons, Vavr or others). Depending on the use case, we could come up with a better model design but it doesn't require specific reactive skills.

I'm getting the expected value and no duplicate logs when calling the service with httpie:

```
http POST http://localhost:8080/question thing=hello
HTTP/1.1 200 OK
Content-Length: 108
Content-Type: application/json

{
    "thingFromTheFirstStep": "firstOne",
    "thingFromTheSecondStep": "secondOne",
    "thingFromTheThirdStep": "thirdOne"
}
``` 

With sequential, external calls, the reactive approach could help in several ways:
* better runtime performance with latency and threading; you could perform all calls using the same `WebClient` instance instead of creating a new one for each call.
* better control over SLAs; you can use the `timeout`/`retry` and other related operators to improve the service behavior here
 